### PR TITLE
Implement basic Streamlit dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # dashboard_py
+
+Este projeto contém um pequeno exemplo de dashboard construido com [Streamlit](https://streamlit.io/).
+
+## Pré-requisitos
+
+Instale as dependências executando:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Como executar
+
+Para iniciar o dashboard execute o comando:
+
+```bash
+streamlit run dashboard/app.py
+```
+
+O Streamlit abrirá o aplicativo no navegador padrão.

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,0 +1,17 @@
+import streamlit as st
+import pandas as pd
+import numpy as np
+
+
+def main():
+    st.title("Demo Dashboard")
+    data = pd.DataFrame(
+        np.random.randn(10, 2),
+        columns=["column A", "column B"]
+    )
+    st.write("Random data")
+    st.line_chart(data)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+streamlit
+pandas
+numpy


### PR DESCRIPTION
## Summary
- add Streamlit app skeleton with a simple line chart
- document install and run instructions
- specify basic dependencies

## Testing
- `python -m py_compile dashboard/app.py`

------
https://chatgpt.com/codex/tasks/task_e_684060fe0b388321820855a331e70704